### PR TITLE
Fix the locale(mkt) not working as expected issue in China

### DIFF
--- a/src/BingPhoto.php
+++ b/src/BingPhoto.php
@@ -140,7 +140,7 @@ class BingPhoto
      */
     private function fetchImageMetadata(): void
     {
-        $url = sprintf(self::BASE_URL . self::JSON_URL . '&idx=%d&n=%d&mkt=%s',
+        $url = sprintf(self::BASE_URL . self::JSON_URL . '&idx=%d&n=%d&mbl=1&mkt=%s',
             $this->args['date'], $this->args['n'], $this->args['locale']);
 
         $data = json_decode(file_get_contents($url), true);


### PR DESCRIPTION
There's an issue with same problem reported to https://github.com/neffo/bing-wallpaper-gnome-extension/issues/20.
Add a param ```mbl=1``` to query will solve.